### PR TITLE
Log full script as separate file

### DIFF
--- a/rawdog/llm_client.py
+++ b/rawdog/llm_client.py
@@ -1,4 +1,5 @@
 import ast
+import datetime
 import json
 import os
 from textwrap import dedent
@@ -57,6 +58,16 @@ class LLMClient:
             log["response"] = text
             cost = completion_cost(completion_response=response) or 0
             log["cost"] = f"{float(cost):.10f}"
+            timestamp = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+            script_filename = self.log_path.parent / f"script_{timestamp}.py"
+
+            script_content = dedent(f"""\
+                    # Model: {log['model']}
+                    # Prompt: {log['prompt']}
+                    # Response Cost: {log.get('cost', 'N/A')}
+                    """)+text.split('```')[1]
+            with open(script_filename, "w") as script_file:
+                script_file.write(script_content)
             return text
         except Exception as e:
             log["error"] = str(e)


### PR DESCRIPTION
I predict fairly often people will generate a script that they turn out to want a lot and then for reliability/latency it'll be nice if it's easy for them to access and reuse.