### PR TITLE
docs(README.md): fix error

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Please proceed with caution. This obviously has the potential to cause harm if s
 ### Quickstart
 1. Install rawdog with pip:
     ```
-    pip install rawdog-ai
+    pip install rawdog-ai litellm
     ```
 
 2. Choose a mode of interaction. You will be prompted to input an API key if not found:


### PR DESCRIPTION
Fix https://github.com/lloydchang/AbanteAI-rawdog/issues/1 ModuleNotFoundError: No module named 'litellm'

While litellm has been added to requirements.txt via https://github.com/AbanteAI/rawdog/commit/abfbc919f643ad8815487104e72623ed11eb10c4

The version of rawdog on pip, paired with README.md instructions, is missing a reference to litellm.

Hence the simplest workaround is to amend README.md instructions as follows:

pip install rawdog-ai litellm