### PR TITLE
Support local openapi-style api

### DIFF
--- a/src/rawdog/utils.py
+++ b/src/rawdog/utils.py
@@ -39,6 +39,9 @@ def get_llm_api_key():
     config = load_config()
     return config.get('llm_api_key')
 
+def get_llm_custom_provider():
+    config = load_config()
+    return config.get('llm_custom_provider')
 
 def set_llm_model(model_name: str):
     config = load_config()
@@ -55,4 +58,9 @@ def set_llm_api_key(api_key: str):
 def set_base_url(base_url: str):
     config = load_config()
     config['llm_base_url'] = base_url
+    save_config(config)
+
+def set_llm_custom_provider(custom_provider: str):
+    config = load_config()
+    config['llm_custom_provider'] = custom_provider
     save_config(config)


### PR DESCRIPTION
Was playing with running this against oobabooga's local mock-openai API. Fixed 2 things that were causing errors:
- Need to set `custom_llm_provider` arg in the call to `completion` (for ooba, set it to "openapi")
- Don't run `completion_cost` if using a custom provider (it throws an error because the custom model isn't in the JSON file it uses to determine cost)