### PR TITLE
Update litellm version to solve ollama compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ description = "An AI command-line assistant"
 readme = "README.md"
 dependencies = [
     "matplotlib>=3.8.2",
-    "litellm>=1.20.5"
+    "litellm>=1.22.3"
 ]
 requires-python = ">=3.8"
 classifiers = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 contourpy==1.2.0
 cycler==0.12.1
 fonttools==4.47.2
-litellm==1.20.5
+litellm==1.22.3
 kiwisolver==1.4.5
 matplotlib==3.8.2
 numpy==1.26.3

--- a/src/rawdog/__main__.py
+++ b/src/rawdog/__main__.py
@@ -9,12 +9,12 @@ from rawdog.llm_client import LLMClient
 llm_client = LLMClient()  # Will prompt for API key if not found
 
 
-def rawdog(prompt: str, verbose: bool=False):
+def rawdog(prompt: str, verbose: bool=False, temperature: float=1.0):
     _continue = True
     while _continue is True:
         error, script, output = "", "", ""
         try:
-            message, script = llm_client.get_script(prompt)
+            message, script = llm_client.get_script(prompt, temperature)
             if script:
                 if verbose:
                     _message = f"{message}\n" if message else ""
@@ -63,6 +63,7 @@ def main():
     parser = argparse.ArgumentParser(description='A smart assistant that can execute Python code to help or hurt you.')
     parser.add_argument('prompt', nargs='*', help='Prompt for direct execution. If empty, enter conversation mode')
     parser.add_argument('--dry-run', action='store_true', help='Print the script before executing and prompt for confirmation.')
+    parser.add_argument('--temperature', type=float, default=1.0, help='The temperature of the language model (default: 1.)')
     args = parser.parse_args()
 
     if len(args.prompt) > 0:
@@ -74,7 +75,7 @@ def main():
                 print("\nWhat can I do for you? (Ctrl-C to exit)")
                 prompt = input("> ")
                 print("")
-                rawdog(prompt, verbose=args.dry_run)
+                rawdog(prompt, verbose=args.dry_run, temperature=args.temperature)
             except KeyboardInterrupt:
                 print("Exiting...")
                 break

--- a/src/rawdog/llm_client.py
+++ b/src/rawdog/llm_client.py
@@ -71,6 +71,7 @@ class LLMClient:
     def get_response(
         self, 
         messages: list[dict[str, str]],
+        temperature: float=1.0,
     ) -> str:
         log = {
             "model": self.model,
@@ -84,7 +85,7 @@ class LLMClient:
                 api_key=self.api_key,
                 model=self.model,
                 messages=messages,
-                temperature=1.0,
+                temperature=temperature,
                 custom_llm_provider=self.custom_provider,
             )
             text = (response.choices[0].message.content) or ""
@@ -113,8 +114,8 @@ class LLMClient:
             with open(self.log_path, "a") as f:
                 f.write(json.dumps(log) + "\n")
         
-    def get_script(self, prompt: str):
+    def get_script(self, prompt: str, temperature: float=1.0):
         self.conversation.append({"role": "user", "content": f"PROMPT: {prompt}"})
-        response = self.get_response(self.conversation)
+        response = self.get_response(self.conversation, temperature)
         self.conversation.append({"role": "system", "content": response})
         return parse_script(response)


### PR DESCRIPTION
Solves #3. 

Since ollama returns stream of jsons by default, litellm needs to explicitly specify `stream=False` in the request. This is fixed in the [newer litellm version](https://github.com/BerriAI/litellm/commit/01cef1fe9eddd76aa82657997bbc5d2a39bfab32)