### PR TITLE
Bump litellm version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ description = "An AI command-line assistant"
 readme = "README.md"
 dependencies = [
     "matplotlib>=3.8.2",
-    "litellm>=1.20.5"
+    "litellm>=1.22.3"
 ]
 requires-python = ">=3.8"
 classifiers = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 contourpy==1.2.0
 cycler==0.12.1
 fonttools==4.47.2
-litellm==1.20.5
+litellm==1.22.3
 kiwisolver==1.4.5
 matplotlib==3.8.2
 numpy==1.26.3


### PR DESCRIPTION
Solves #3. 

Since ollama returns stream of jsons by default, litellm needs to explicitly specify `stream=False` in the request. This is fixed in the [newer litellm version](https://github.com/BerriAI/litellm/commit/01cef1fe9eddd76aa82657997bbc5d2a39bfab32)