### PR TITLE
clean up setting config

### DIFF
--- a/src/rawdog/llm_client.py
+++ b/src/rawdog/llm_client.py
@@ -16,10 +16,6 @@ from rawdog.utils import (
     get_llm_model,
     get_llm_temperature,
     rawdog_dir,
-    set_base_url,
-    set_llm_custom_provider,
-    set_llm_model,
-    set_llm_temperature,
 )
 
 
@@ -55,14 +51,9 @@ class LLMClient:
     def __init__(self):
         self.log_path = rawdog_dir / "logs.jsonl"
         self.base_url = get_llm_base_url()
-        set_base_url(self.base_url)
         self.model = get_llm_model() or "gpt-4"
-        set_llm_model(self.model)
         self.custom_provider = get_llm_custom_provider() or None
-        set_llm_custom_provider(self.custom_provider)
-        cfg_temperature = get_llm_temperature()
-        self.temperature = cfg_temperature if cfg_temperature is not None else 1.0
-        set_llm_temperature(self.temperature)
+        self.temperature = get_llm_temperature() or 1.0
 
         # In general it's hard to know if the user needs an API key or which environment variables to set
         # If they're using the defaults they'll need to set the OPENAI_API_KEY environment variable

--- a/src/rawdog/utils.py
+++ b/src/rawdog/utils.py
@@ -49,13 +49,18 @@ def load_config():
     if config_path.exists():
         with open(config_path, "r") as f:
             return yaml.safe_load(f)
-    else:
-        return {}
 
-
-def save_config(config):
+    # create empty config for users to configure easily
+    config = {
+        "llm_base_url": None,
+        "llm_custom_provider": None,
+        "llm_model": None,
+        "llm_temperature": None,
+    }
     with open(config_path, "w") as f:
         yaml.safe_dump(config, f)
+
+    return config
 
 
 # Config helpers
@@ -77,27 +82,3 @@ def get_llm_custom_provider():
 def get_llm_temperature():
     config = load_config()
     return config.get("llm_temperature")
-
-
-def set_llm_model(model_name: str):
-    config = load_config()
-    config["llm_model"] = model_name
-    save_config(config)
-
-
-def set_base_url(base_url: str):
-    config = load_config()
-    config["llm_base_url"] = base_url
-    save_config(config)
-
-
-def set_llm_custom_provider(custom_provider: str):
-    config = load_config()
-    config["llm_custom_provider"] = custom_provider
-    save_config(config)
-
-
-def set_llm_temperature(temperature: float):
-    config = load_config()
-    config["llm_temperature"] = temperature
-    save_config(config)


### PR DESCRIPTION
previously was re-saving config 4 times every run, filling it with default values.

this would cause problems later if we changed defaults - user configs now have the old defaults hard-coded.

now we set up config with `None` for all values, so it exists and easy for users to change.

Keep in mind old user configs still around with `llm-model=gpt-4` and `temperature=1.0` possibly hard coded