### PR TITLE
add pyreadline3 req for Windows

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ python-dateutil==2.8.2
 pytz==2023.4
 six==1.16.0
 tzdata==2023.4
+pyreadline3==3.4.1; platform_system == "Windows"


### PR DESCRIPTION
`readline` isn't available on Windows, so Windows users will need to install `pyreadline3`

https://github.com/AbanteAI/rawdog/issues/39