### PR TITLE
Rawdog from venv

### DIFF
--- a/src/rawdog/__main__.py
+++ b/src/rawdog/__main__.py
@@ -6,6 +6,7 @@ import readline
 from contextlib import redirect_stdout
 
 from rawdog import __version__
+from rawdog.execute_script import execute_script
 from rawdog.llm_client import LLMClient
 from rawdog.utils import history_file
 
@@ -29,9 +30,7 @@ def rawdog(prompt: str, verbose: bool = False):
                     print(f"{80 * '-'}\n{_message}{script}\n{80 * '-'}")
                     if input("Proceed with execution? (Y/n):").strip().lower() == "n":
                         raise Exception("Execution cancelled by user")
-                with io.StringIO() as buf, redirect_stdout(buf):
-                    exec(script, globals())
-                    output = buf.getvalue()
+                output = execute_script(script)
             elif message:
                 print(message)
         except KeyboardInterrupt:

--- a/src/rawdog/execute_script.py
+++ b/src/rawdog/execute_script.py
@@ -1,11 +1,11 @@
 import subprocess
-import sys
 import tempfile
 
+from rawdog.utils import get_rawdog_python_executable
 
-def execute_script(script: str, python_executable: str = None) -> str:
-    if python_executable is None:
-        python_executable = sys.executable
+
+def execute_script(script: str) -> str:
+    python_executable = get_rawdog_python_executable()
     with tempfile.NamedTemporaryFile(mode='w+', delete=False) as tmp_script:
         tmp_script_name = tmp_script.name
         tmp_script.write(script)

--- a/src/rawdog/execute_script.py
+++ b/src/rawdog/execute_script.py
@@ -1,0 +1,15 @@
+import subprocess
+import sys
+import tempfile
+
+
+def execute_script(script: str, python_executable: str = None) -> str:
+    if python_executable is None:
+        python_executable = sys.executable
+    with tempfile.NamedTemporaryFile(mode='w+', delete=False) as tmp_script:
+        tmp_script_name = tmp_script.name
+        tmp_script.write(script)
+        tmp_script.flush()
+        result = subprocess.run([python_executable, tmp_script_name], capture_output=True, text=True)
+        output = result.stdout
+    return output

--- a/src/rawdog/utils.py
+++ b/src/rawdog/utils.py
@@ -1,8 +1,10 @@
 import datetime
 import platform
-from pathlib import Path
-
+import subprocess
+import sys
 import yaml
+from pathlib import Path
+from subprocess import DEVNULL
 
 # Rawdog dir
 rawdog_dir = Path.home() / ".rawdog"
@@ -82,3 +84,23 @@ def get_llm_custom_provider():
 def get_llm_temperature():
     config = load_config()
     return config.get("llm_temperature")
+
+
+# Script execution environment
+def get_rawdog_python_executable():
+    venv_dir = rawdog_dir / 'venv'
+    if platform.system() == "Windows":
+        python_executable = venv_dir / 'Scripts' / 'python'
+    else:
+        python_executable = venv_dir / 'bin' / 'python'
+    if not venv_dir.exists():
+        print(f"Creating virtual environment in {venv_dir}...")
+        subprocess.run([sys.executable, "-m", "venv", str(venv_dir)], stdout=DEVNULL, stderr=DEVNULL, check=True)
+        install_pip_packages("matplotlib", "pandas", "numpy")
+    return str(python_executable)
+
+
+def install_pip_packages(*packages: str):
+    python_executable = get_rawdog_python_executable()
+    print(f"Installing {', '.join(packages)} with pip...")
+    subprocess.run([python_executable, "-m", "pip", "install", *packages], stdout=DEVNULL, stderr=DEVNULL, check=True)


### PR DESCRIPTION
Creates a new venv in `~/.rawdog`, installs basic deps (matplotlib, pandas + numpy), and executes all scripts from there.

This way the `cwd` is still where the user calls from, but it always uses the executable/packages from that venv.

I also setup `utils.install_pip_packages`, which we can later use to auto-install packages rawdog wants to use.