### PR TITLE
Dry run now a config setting

### DIFF
--- a/src/rawdog/config.py
+++ b/src/rawdog/config.py
@@ -11,6 +11,11 @@ default_config = {
     "llm_model": "gpt-4-turbo-preview",
     "llm_custom_provider": None,
     "llm_temperature": 1.0,
+    "dry_run": False,
+}
+
+setting_descriptions = {
+    "dry_run": "Print the script before executing and prompt for confirmation.",
 }
 
 
@@ -36,14 +41,24 @@ def read_config_file():
 
 def add_config_flags_to_argparser(parser):
     for k in default_config.keys():
-        parser.add_argument(f"--{k}", default=None, help=f"Set the {k} config value")
+        normalized = k.replace("_", "-")
+        if k in setting_descriptions:
+            help_text = setting_descriptions[k]
+        else:
+            help_text = f"Set the {normalized} config value"
+        if default_config[k] is False:
+            parser.add_argument(f"--{normalized}", action="store_true", help=help_text)
+        else:
+            parser.add_argument(f"--{normalized}", default=None, help=help_text)
 
 
 def get_config(args=None):
     config = read_config_file()
     if args:
         config_args = {
-            k: v for k, v in vars(args).items() if k in default_config and v is not None
+            k.replace("-", "_"): v
+            for k, v in vars(args).items()
+            if k in default_config and v is not None and v is not False
         }
         config = {**config, **config_args}
     return config


### PR DESCRIPTION
Flag config settings expect dashes now instead of underscores. Config settings can now add a help message in the setting_description dictionary. The rawdog method now gets the config and makes its own llm_client and determines verbosity from the config.