### PR TITLE
Pip install not found modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ version = "0.1.2"
 description = "An AI command-line assistant"
 readme = "README.md"
 dependencies = [
-    "matplotlib>=3.8.2",
     "litellm>=1.22.3"
 ]
 requires-python = ">=3.8"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,17 +1,2 @@
-beautifulsoup4==4.12.3
-contourpy==1.2.0
-cycler==0.12.1
-fonttools==4.47.2
 litellm==1.22.3
-kiwisolver==1.4.5
-matplotlib==3.8.2
-numpy==1.26.3
 packaging==23.2
-pandas==2.2.0
-pillow==10.2.0
-pyparsing==3.1.1
-python-dateutil==2.8.2
-pytz==2023.4
-six==1.16.0
-tzdata==2023.4
-pyreadline3==3.4.1; platform_system == "Windows"

--- a/src/rawdog/__main__.py
+++ b/src/rawdog/__main__.py
@@ -3,12 +3,11 @@ import os
 import platform
 import readline
 
-import history_file
-
 from rawdog import __version__
 from rawdog.config import add_config_flags_to_argparser, get_config
 from rawdog.execute_script import execute_script
 from rawdog.llm_client import LLMClient
+from rawdog.utils import history_file
 
 
 def rawdog(prompt: str, config, llm_client):
@@ -33,7 +32,7 @@ def rawdog(prompt: str, config, llm_client):
                         == "n"
                     ):
                         raise Exception("Execution cancelled by user")
-                output, error = execute_script(script)
+                output, error = execute_script(script, llm_client)
             elif message:
                 print(message)
         except KeyboardInterrupt:

--- a/src/rawdog/__main__.py
+++ b/src/rawdog/__main__.py
@@ -3,11 +3,12 @@ import os
 import platform
 import readline
 
+import history_file
+
 from rawdog import __version__
 from rawdog.config import add_config_flags_to_argparser, get_config
 from rawdog.execute_script import execute_script
 from rawdog.llm_client import LLMClient
-from rawdog.utils import history_file
 
 
 def rawdog(prompt: str, llm_client, verbose: bool = False):
@@ -24,15 +25,18 @@ def rawdog(prompt: str, llm_client, verbose: bool = False):
             if script:
                 if verbose:
                     print(f"{80 * '-'}")
-                    if input("Execute script in markdown block? (Y/n):").strip().lower() == "n":
+                    if (
+                        input("Execute script in markdown block? (Y/n): ")
+                        .strip()
+                        .lower()
+                        == "n"
+                    ):
                         raise Exception("Execution cancelled by user")
-                output = execute_script(script)
+                output, error = execute_script(script)
             elif message:
                 print(message)
         except KeyboardInterrupt:
             error = "Execution interrupted by user"
-        except Exception as e:
-            error = f"Execution error: {e}"
 
         _continue = output and output.strip().endswith("CONTINUE")
         if error:

--- a/src/rawdog/execute_script.py
+++ b/src/rawdog/execute_script.py
@@ -36,7 +36,7 @@ def install_pip_packages(*packages: str):
     )
 
 
-def execute_script(script: str) -> str:
+def execute_script(script: str, llm_client) -> str:
     python_executable = get_rawdog_python_executable()
     with tempfile.NamedTemporaryFile(mode="w+", delete=False) as tmp_script:
         tmp_script_name = tmp_script.name
@@ -55,15 +55,16 @@ def execute_script(script: str) -> str:
                 match = re.search(r"No module named '(\w+)'", error)
                 if match:
                     module = match.group(1)
+                    module_name = llm_client.get_python_package(module)
                     if (
                         input(
-                            f"Rawdog wants to use {module}. Install to rawdog's venv with pip (Y/n): "
+                            f"Rawdog wants to use {module_name}. Install to rawdog's venv with pip (Y/n): "
                         )
                         .strip()
                         .lower()
                         != "n"
                     ):
-                        install_result = install_pip_packages(module)
+                        install_result = install_pip_packages(module_name)
                         if install_result.returncode == 0:
                             retry = True
                         else:

--- a/src/rawdog/execute_script.py
+++ b/src/rawdog/execute_script.py
@@ -58,7 +58,7 @@ def execute_script(script: str, llm_client) -> str:
                     module_name = llm_client.get_python_package(module)
                     if (
                         input(
-                            f"Rawdog wants to use {module_name}. Install to rawdog's venv with pip (Y/n): "
+                            f"Rawdog wants to use {module_name}. Install to rawdog's venv with pip? (Y/n): "
                         )
                         .strip()
                         .lower()

--- a/src/rawdog/execute_script.py
+++ b/src/rawdog/execute_script.py
@@ -1,15 +1,71 @@
+import platform
+import re
 import subprocess
+import sys
 import tempfile
+from subprocess import DEVNULL
 
-from rawdog.utils import get_rawdog_python_executable
+from rawdog.utils import rawdog_dir
+
+
+# Script execution environment
+def get_rawdog_python_executable():
+    venv_dir = rawdog_dir / "venv"
+    if platform.system() == "Windows":
+        python_executable = venv_dir / "Scripts" / "python"
+    else:
+        python_executable = venv_dir / "bin" / "python"
+    if not venv_dir.exists():
+        print(f"Creating virtual environment in {venv_dir}...")
+        subprocess.run(
+            [sys.executable, "-m", "venv", str(venv_dir)],
+            stdout=DEVNULL,
+            stderr=DEVNULL,
+            check=True,
+        )
+    return str(python_executable)
+
+
+def install_pip_packages(*packages: str):
+    python_executable = get_rawdog_python_executable()
+    print(f"Installing {', '.join(packages)} with pip...")
+    return subprocess.run(
+        [python_executable, "-m", "pip", "install", *packages],
+        capture_output=True,
+        check=True,
+    )
 
 
 def execute_script(script: str) -> str:
     python_executable = get_rawdog_python_executable()
-    with tempfile.NamedTemporaryFile(mode='w+', delete=False) as tmp_script:
+    with tempfile.NamedTemporaryFile(mode="w+", delete=False) as tmp_script:
         tmp_script_name = tmp_script.name
         tmp_script.write(script)
         tmp_script.flush()
-        result = subprocess.run([python_executable, tmp_script_name], capture_output=True, text=True)
-        output = result.stdout
-    return output
+
+        retry = True
+        while retry:
+            retry = False
+            result = subprocess.run(
+                [python_executable, tmp_script_name], capture_output=True, text=True
+            )
+            output = result.stdout
+            error = result.stderr
+            if error and "ModuleNotFoundError: No module named" in error:
+                match = re.search(r"No module named '(\w+)'", error)
+                if match:
+                    module = match.group(1)
+                    if (
+                        input(
+                            f"Rawdog wants to use {module}. Install to rawdog's venv with pip (Y/n): "
+                        )
+                        .strip()
+                        .lower()
+                        != "n"
+                    ):
+                        install_result = install_pip_packages(module)
+                        if install_result.returncode == 0:
+                            retry = True
+                        else:
+                            print("Failed to install package")
+    return output, error

--- a/src/rawdog/llm_client.py
+++ b/src/rawdog/llm_client.py
@@ -37,16 +37,41 @@ class LLMClient:
         ]
         self.session_cost = 0
 
+    def get_python_package(self, import_name: str):
+        base_url = self.config.get("llm_base_url")
+        model = self.config.get("llm_model")
+        custom_llm_provider = self.config.get("llm_custom_provider")
+
+        messages = [
+            {
+                "role": "system",
+                "content": dedent(
+                    f"""\
+                     The following python import failed: import {import_name}. \
+                     Respond with only one word which is the name of the package \
+                     on pypi. For instance if the import is "import numpy", you \
+                     should respond with "numpy". If the import is "import PIL" \
+                     you should respond with "Pillow". If you are unsure respond \
+                     with the original import name."""
+                ),
+            }
+        ]
+
+        response = completion(
+            base_url=base_url,
+            model=model,
+            messages=messages,
+            temperature=0.01,
+            custom_llm_provider=custom_llm_provider,
+        )
+
+        return response.choices[0].message.content
+
     def get_script(self, prompt: Optional[str] = None, stream=False):
         if prompt:
             self.conversation.append({"role": "user", "content": prompt})
         messages = self.conversation.copy()
 
-    def get_response(
-        self,
-        messages: list[dict[str, str]],
-        stream=False,
-    ) -> str:
         base_url = self.config.get("llm_base_url")
         model = self.config.get("llm_model")
         temperature = self.config.get("llm_temperature")
@@ -81,7 +106,10 @@ class LLMClient:
             if custom_llm_provider:
                 cost = 0
             else:
-                cost = completion_cost(model=model, messages=messages, completion=text) or 0
+                cost = (
+                    completion_cost(model=model, messages=messages, completion=text)
+                    or 0
+                )
             self.session_cost += cost
             log["cost"] = f"{float(cost):.10f}"
             metadata = {

--- a/src/rawdog/llm_client.py
+++ b/src/rawdog/llm_client.py
@@ -39,7 +39,7 @@ class LLMClient:
     def get_response(
         self,
         messages: list[dict[str, str]],
-        stream = False,
+        stream=False,
     ) -> str:
         base_url = self.config.get("llm_base_url")
         model = self.config.get("llm_model")
@@ -75,7 +75,10 @@ class LLMClient:
             if custom_llm_provider:
                 cost = 0
             else:
-                cost = completion_cost(model=model, messages=messages, completion=text) or 0
+                cost = (
+                    completion_cost(model=model, messages=messages, completion=text)
+                    or 0
+                )
             log["cost"] = f"{float(cost):.10f}"
             metadata = {
                 "model": model,

--- a/src/rawdog/prompts.py
+++ b/src/rawdog/prompts.py
@@ -40,7 +40,7 @@ Please follow these conventions carefully:
 - Actively clean up any temporary processes or files you use.
 - When looking through files, use git as available to skip files, and skip hidden files (.env, .git, etc) by default.
 - At the user's request, you can inspect and update your configuration file: ~/.rawdog/config.yaml. Changes will take effect after restarting.
-- You can plot anything with matplotlib.
+- Feel free to use any common python packages. For example matplotlib, beautifulsoup4, numpy. If the user doesn't have them installed they will be installed automatically with user confirmation.
 - ALWAYS Return your SCRIPT inside of a single pair of ``` delimiters. Only the console output of the first such SCRIPT is visible to the user, so make sure that it's complete and don't bother returning anything else.
 """
 

--- a/src/rawdog/utils.py
+++ b/src/rawdog/utils.py
@@ -1,11 +1,6 @@
 import datetime
 import platform
-import subprocess
-import sys
 from pathlib import Path
-from subprocess import DEVNULL
-
-import yaml
 
 # Rawdog dir
 rawdog_dir = Path.home() / ".rawdog"
@@ -44,33 +39,3 @@ The user's operating system is {os}
         """.format(
             date=self.date, cwd=self.cwd, is_git=self.is_git, os=self.os
         )
-
-
-# Script execution environment
-def get_rawdog_python_executable():
-    venv_dir = rawdog_dir / "venv"
-    if platform.system() == "Windows":
-        python_executable = venv_dir / "Scripts" / "python"
-    else:
-        python_executable = venv_dir / "bin" / "python"
-    if not venv_dir.exists():
-        print(f"Creating virtual environment in {venv_dir}...")
-        subprocess.run(
-            [sys.executable, "-m", "venv", str(venv_dir)],
-            stdout=DEVNULL,
-            stderr=DEVNULL,
-            check=True,
-        )
-        install_pip_packages("matplotlib", "pandas", "numpy")
-    return str(python_executable)
-
-
-def install_pip_packages(*packages: str):
-    python_executable = get_rawdog_python_executable()
-    print(f"Installing {', '.join(packages)} with pip...")
-    subprocess.run(
-        [python_executable, "-m", "pip", "install", *packages],
-        stdout=DEVNULL,
-        stderr=DEVNULL,
-        check=True,
-    )

--- a/src/rawdog/utils.py
+++ b/src/rawdog/utils.py
@@ -1,5 +1,6 @@
 import datetime
 import platform
+import subprocess
 from pathlib import Path
 
 # Rawdog dir
@@ -33,12 +34,17 @@ class EnvInfo:
         self.os = platform.system()
         self.is_git = "IS" if Path(".git").exists() else "is NOT"
         self.cwd_info = self._get_cwd_info()
-        self.last_commit = "" if not self.is_git else "\nThe last commit message is: " + (
-            subprocess.run(
-                ["git", "log", "-1", "--pretty=%B"], stdout=subprocess.PIPE
+        self.last_commit = (
+            ""
+            if not self.is_git
+            else "\nThe last commit message is: "
+            + (
+                subprocess.run(
+                    ["git", "log", "-1", "--pretty=%B"], stdout=subprocess.PIPE
+                )
+                .stdout.decode()
+                .strip()
             )
-            .stdout.decode()
-            .strip()
         )
 
     def _get_cwd_info(self, max_items=100):
@@ -49,8 +55,8 @@ class EnvInfo:
             name = ("" if not item.is_dir() else "/") + item.name
             last_modified = datetime.datetime.fromtimestamp(
                 item.stat().st_mtime
-            ).strftime("%Y-%m-%d %H:%M:%S") 
-            size = len(list(item.iterdir())) if item.is_dir() else  item.stat().st_size
+            ).strftime("%Y-%m-%d %H:%M:%S")
+            size = len(list(item.iterdir())) if item.is_dir() else item.stat().st_size
             unit = " bytes" if item.is_file() else " items"
             output.append(f"{last_modified} {size:10}{unit} {name}")
         if not output:
@@ -64,10 +70,10 @@ The current working directory is {cwd}, which {is_git} a git repository.
 The user's operating system is {os}.
 The contents of the current working directory are:
 {cwd_info}{last_commit}""".format(
-            date=self.date, 
-            cwd=self.cwd, 
-            is_git=self.is_git, 
-            os=self.os, 
+            date=self.date,
+            cwd=self.cwd,
+            is_git=self.is_git,
+            os=self.os,
             cwd_info=self.cwd_info,
-            last_commit=self.last_commit, 
+            last_commit=self.last_commit,
         )


### PR DESCRIPTION
If the llm tries to use a module that cannot be found then prompt the user to install it with pip. An llm call is used to determine the package name.

Misc:
* Moved execution specific utils from utils to execute_script
* Removed almost all the requirements
* Give errors from the script to the llm (was broken by move to subprocess)