### PR TITLE
Use a different model to guess pip and respond

### DIFF
--- a/src/rawdog/config.py
+++ b/src/rawdog/config.py
@@ -10,7 +10,7 @@ default_config = {
     "llm_api_key": None,
     "llm_base_url": None,
     "llm_model": "gpt-4-turbo-preview",
-    "pip_model": None
+    "pip_model": None,
     "llm_custom_provider": None,
     "llm_temperature": 1.0,
     "retries": 2,

--- a/src/rawdog/config.py
+++ b/src/rawdog/config.py
@@ -10,6 +10,7 @@ default_config = {
     "llm_api_key": None,
     "llm_base_url": None,
     "llm_model": "gpt-4-turbo-preview",
+    "pip_model": None
     "llm_custom_provider": None,
     "llm_temperature": 1.0,
     "retries": 2,
@@ -21,6 +22,7 @@ default_config = {
 setting_descriptions = {
     "retries": "If the script fails, retry this many times before giving up.",
     "leash": "Print the script before executing and prompt for confirmation.",
+    "pip_model": "The model to use to get package name from import name.",
 }
 
 

--- a/src/rawdog/llm_client.py
+++ b/src/rawdog/llm_client.py
@@ -46,7 +46,14 @@ class LLMClient:
 
     def get_python_package(self, import_name: str):
         base_url = self.config.get("llm_base_url")
-        model = self.config.get("llm_model")
+        model = self.config.get("pip_model")
+        llm_model = self.config.get("llm_model")
+        if model is None:
+            if "ft:" in llm_model or "rawdog" in llm_model or "abante" in llm_model:
+                model = "gpt-3.5-turbo"
+            else:
+                model = llm_model
+
         custom_llm_provider = self.config.get("llm_custom_provider")
 
         messages = [


### PR DESCRIPTION
If we finetune a model it will learn to always respond in python surrounded with backticks so it won't be able to produce pip packages well. We need to have a different model.