### PR TITLE
Add pyreadline to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ version = "0.1.6"
 description = "An AI command-line assistant"
 readme = "README.md"
 dependencies = [
-    "litellm>=1.22.3"
+    "litellm>=1.22.3",
+    "pyreadline3==3.4.1; platform_system == 'Windows'"
 ]
 requires-python = ">=3.8"
 classifiers = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-litellm==1.22.3
-packaging==23.2
-pyreadline3==3.4.1; platform_system == "Windows"


### PR DESCRIPTION
This project is installed from the pyproject.toml which doesn't reference the requirements.txt. We should probably either dynamically import the `requirements.txt` or delete it and only store the dependencies in the pyproject.toml. I favor deleting the requirements.txt.